### PR TITLE
add keywords: page, margins

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -16,6 +16,8 @@ keywords = [
   "margin",
   "header",
   "footer",
+  "page",
+  "margins",
 ]
 exclude = [
   ".github",


### PR DESCRIPTION
I was looking at some posts from before where page margins are computed, but instead found [this one](https://forum.typst.app/t/how-to-compute-the-current-pages-textwidth/6523/3?u=andrew).

The package search, however, isn't very useful as [page](https://typst.app/universe/search/?kind=packages&q=page) and [margins](https://typst.app/universe/search/?kind=packages&q=margins) do not show this package, yet it's probably the perfect tool for the job.

This PR fixes that.

The page/margin usage/function: https://forum.typst.app/t/how-to-measure-auto-page-dimensions/7445/2?u=andrew.